### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -92,9 +92,9 @@ pub fn find_reduced_test_case<F: Fn(Path) -> bool + panic::UnwindSafe + panic::R
     for poly in &polygons {
         let mut poly_iter = poly.iter();
         let pos = *poly_iter.next().unwrap();
-        println!("    builder.begin(point({:.}, {:.}));", pos.x, pos.y);
+        println!("    builder.begin(point({}, {}));", pos.x, pos.y);
         for pos in poly_iter {
-            println!("    builder.line_to(point({:.}, {:.}));", pos.x, pos.y);
+            println!("    builder.line_to(point({}, {}));", pos.x, pos.y);
         }
         println!("    builder.close();\n");
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.